### PR TITLE
Use package-file directive in Cask

### DIFF
--- a/Cask
+++ b/Cask
@@ -1,7 +1,7 @@
-(package "org-ioslide" "0.1.0" "Export org-mode to Google I/O HTML5 slide.")
-
 (source melpa)
 (source org)
+
+(package-file "ox-ioslide.el")
 
 (depends-on "org-plus-contrib")
 


### PR DESCRIPTION
This prevents duplication of metadata between the Cask file and the headers in ox-ioslide.el.