### PR TITLE
Make ox-ioslide.el compatible with ox-html HEAD.

### DIFF
--- a/ox-ioslide.el
+++ b/ox-ioslide.el
@@ -464,7 +464,9 @@ holding contextual information."
          (priority (and (plist-get info :with-priority)
                         (org-element-property :priority headline)))
          ;; Create the headline text.
-         (full-text (org-html-format-headline--wrap headline info)))
+         (full-text (if (fboundp 'org-html-format-headline--wrap)
+                        (org-html-format-headline--wrap headline info)
+                     (org-html-headline headline contents info))))
     (cond
      ;; Case 1: This is a footnote section: ignore it.
      ((org-element-property :footnote-section-p headline) nil)
@@ -564,7 +566,9 @@ holding contextual information."
        (or hgroup-class "")
        ;; headline text.
        (or title-class "")
-       (org-html-format-headline--wrap headline info)
+       (if (fboundp 'org-html-format-headline--wrap)
+           (org-html-format-headline--wrap headline info)
+         (org-html-headline headline contents info))
        ;; subtitle
        (or (org-element-property :SUBTITLE headline) "")))))
 


### PR DESCRIPTION
Use org-html-headline instead of org-html-format-headline--wrap, since
the latter has been refactored away in org-mode HEAD. See
http://orgmode.org/w/?p=org-mode.git;a=commitdiff;h=c9ca0b6df86de13a5302b5a3c955fb2fb1023d36;hp=3c22bb19e025e350ebcc25c6fc23e2dd59e49693