### PR TITLE
Fix compatibility with recent org-mode.

### DIFF
--- a/ox-ioslide.el
+++ b/ox-ioslide.el
@@ -161,8 +161,6 @@ vertical slides."
     (footnote-definition        .       org-ioslide-footnote-definition)
     (footnote-reference         .       org-ioslide-footnote-reference)
     )
-
-  :export-block '("NOTE")
   )
 
 


### PR DESCRIPTION
The `export-block` keyword has been removed from the export backend
definiton, resulting in the following error while initializing org-ioslide:
```
org-export-define-derived-backend: Unknown keyword: :export-block
```

Reference:
http://orgmode.org/cgit.cgi/org-mode.git/commit/?id=54318add34f09ff39d3fd034a4c1a89f60fd8759