### PR TITLE
Replace `org-export-solidify-link-text`

### DIFF
--- a/ox-ioslide.el
+++ b/ox-ioslide.el
@@ -407,7 +407,7 @@ contextual information."
           (label (let ((lbl (org-element-property :name src-block)))
                    (if (not lbl) ""
                      (format " id=\"%s\""
-                             (org-export-solidify-link-text lbl))))))
+                             (org-export-get-reference lbl info))))))
       (if (not lang)
           ;; Use org-html-src-block to genterate HTML code.
           (org-html-src-block src-block contents info)


### PR DESCRIPTION
Use `org-export-get-reference` instead.

Fixes #44 

ref:
http://orgmode.org/w/?p=org-mode.git;a=blobdiff;f=lisp/ox.el;h=d6dcc826290927f56e211328447c9e8d507797aa;hp=a6afc304af79444236905e12195fba0e13fdc831;hb=68eb1d0ab0c153a1403d3c80fb3049ddc57aa26c;hpb=459033265295723cbfb0fccb3577acbfdc9d0285

Signed-off-by: Yen-Chin Lee coldnew.tw@gmail.com
